### PR TITLE
Make APIs dependency injection friendly

### DIFF
--- a/dotnet-algorand-sdk/V2/Algod/CommonApi.cs
+++ b/dotnet-algorand-sdk/V2/Algod/CommonApi.cs
@@ -119,7 +119,7 @@ namespace Algorand.V2.Algod
         public async System.Threading.Tasks.Task HealthAsync(System.Threading.CancellationToken cancellationToken)
         {
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("/health");
+            urlBuilder_.Append("health");
 
             var client_ = _httpClient;
             var disposeClient_ = false;
@@ -189,7 +189,7 @@ namespace Algorand.V2.Algod
         public async System.Threading.Tasks.Task MetricsAsync(System.Threading.CancellationToken cancellationToken)
         {
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("/metrics");
+            urlBuilder_.Append("metrics");
 
             var client_ = _httpClient;
             var disposeClient_ = false;
@@ -265,7 +265,7 @@ namespace Algorand.V2.Algod
         public async System.Threading.Tasks.Task<string> GenesisAsync(System.Threading.CancellationToken cancellationToken)
         {
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("/genesis");
+            urlBuilder_.Append("genesis");
 
             var client_ = _httpClient;
             var disposeClient_ = false;
@@ -341,7 +341,7 @@ namespace Algorand.V2.Algod
         public async System.Threading.Tasks.Task<string> Swagger_jsonAsync(System.Threading.CancellationToken cancellationToken)
         {
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("/swagger.json");
+            urlBuilder_.Append("swagger.json");
 
             var client_ = _httpClient;
             var disposeClient_ = false;
@@ -415,7 +415,7 @@ namespace Algorand.V2.Algod
         public async System.Threading.Tasks.Task<Version> VersionsAsync(System.Threading.CancellationToken cancellationToken)
         {
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("/versions");
+            urlBuilder_.Append("versions");
 
             var client_ = _httpClient;
             var disposeClient_ = false;

--- a/dotnet-algorand-sdk/V2/Algod/CommonApi.cs
+++ b/dotnet-algorand-sdk/V2/Algod/CommonApi.cs
@@ -80,7 +80,6 @@ namespace Algorand.V2.Algod
     [System.CodeDom.Compiler.GeneratedCode("NSwag", "13.14.5.0 (NJsonSchema v10.5.2.0 (Newtonsoft.Json v12.0.0.0))")]
     public partial class CommonApi : ICommonApi
     {
-        private string _baseUrl = "http://localhost/";
         private System.Net.Http.HttpClient _httpClient;
         private System.Lazy<Newtonsoft.Json.JsonSerializerSettings> _settings;
 
@@ -95,12 +94,6 @@ namespace Algorand.V2.Algod
             var settings = new Newtonsoft.Json.JsonSerializerSettings();
             UpdateJsonSerializerSettings(settings);
             return settings;
-        }
-
-        public string BaseUrl
-        {
-            get { return _baseUrl; }
-            set { _baseUrl = value; }
         }
 
         protected Newtonsoft.Json.JsonSerializerSettings JsonSerializerSettings { get { return _settings.Value; } }
@@ -126,7 +119,7 @@ namespace Algorand.V2.Algod
         public async System.Threading.Tasks.Task HealthAsync(System.Threading.CancellationToken cancellationToken)
         {
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/health");
+            urlBuilder_.Append("/health");
 
             var client_ = _httpClient;
             var disposeClient_ = false;
@@ -196,7 +189,7 @@ namespace Algorand.V2.Algod
         public async System.Threading.Tasks.Task MetricsAsync(System.Threading.CancellationToken cancellationToken)
         {
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/metrics");
+            urlBuilder_.Append("/metrics");
 
             var client_ = _httpClient;
             var disposeClient_ = false;
@@ -272,7 +265,7 @@ namespace Algorand.V2.Algod
         public async System.Threading.Tasks.Task<string> GenesisAsync(System.Threading.CancellationToken cancellationToken)
         {
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/genesis");
+            urlBuilder_.Append("/genesis");
 
             var client_ = _httpClient;
             var disposeClient_ = false;
@@ -348,7 +341,7 @@ namespace Algorand.V2.Algod
         public async System.Threading.Tasks.Task<string> Swagger_jsonAsync(System.Threading.CancellationToken cancellationToken)
         {
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/swagger.json");
+            urlBuilder_.Append("/swagger.json");
 
             var client_ = _httpClient;
             var disposeClient_ = false;
@@ -422,7 +415,7 @@ namespace Algorand.V2.Algod
         public async System.Threading.Tasks.Task<Version> VersionsAsync(System.Threading.CancellationToken cancellationToken)
         {
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/versions");
+            urlBuilder_.Append("/versions");
 
             var client_ = _httpClient;
             var disposeClient_ = false;

--- a/dotnet-algorand-sdk/V2/Algod/DefaultApi.cs
+++ b/dotnet-algorand-sdk/V2/Algod/DefaultApi.cs
@@ -235,7 +235,6 @@ namespace Algorand.V2.Algod
     [System.CodeDom.Compiler.GeneratedCode("NSwag", "13.14.5.0 (NJsonSchema v10.5.2.0 (Newtonsoft.Json v12.0.0.0))")]
     public partial class DefaultApi : IDefaultApi
     {
-        private string _baseUrl = "http://localhost/";
         private System.Net.Http.HttpClient _httpClient;
         private System.Lazy<Newtonsoft.Json.JsonSerializerSettings> _settings;
 
@@ -250,12 +249,6 @@ namespace Algorand.V2.Algod
             var settings = new Newtonsoft.Json.JsonSerializerSettings();
             UpdateJsonSerializerSettings(settings);
             return settings;
-        }
-
-        public string BaseUrl
-        {
-            get { return _baseUrl; }
-            set { _baseUrl = value; }
         }
 
         protected Newtonsoft.Json.JsonSerializerSettings JsonSerializerSettings { get { return _settings.Value; } }
@@ -286,7 +279,7 @@ namespace Algorand.V2.Algod
                 throw new System.ArgumentNullException("address");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/v2/accounts/{address}?");
+            urlBuilder_.Append("/v2/accounts/{address}?");
             urlBuilder_.Replace("{address}", System.Uri.EscapeDataString(ConvertToString(address, System.Globalization.CultureInfo.InvariantCulture)));
             if (format != null)
             {
@@ -407,7 +400,7 @@ namespace Algorand.V2.Algod
                 throw new System.ArgumentNullException("address");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/v2/accounts/{address}/transactions/pending?");
+            urlBuilder_.Append("/v2/accounts/{address}/transactions/pending?");
             urlBuilder_.Replace("{address}", System.Uri.EscapeDataString(ConvertToString(address, System.Globalization.CultureInfo.InvariantCulture)));
             if (max != null)
             {
@@ -540,7 +533,7 @@ namespace Algorand.V2.Algod
                 throw new System.ArgumentNullException("round");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/v2/blocks/{round}?");
+            urlBuilder_.Append("/v2/blocks/{round}?");
             urlBuilder_.Replace("{round}", System.Uri.EscapeDataString(ConvertToString(round, System.Globalization.CultureInfo.InvariantCulture)));
             if (format != null)
             {
@@ -675,7 +668,7 @@ namespace Algorand.V2.Algod
                 throw new System.ArgumentNullException("txid");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/v2/blocks/{round}/transactions/{txid}/proof?");
+            urlBuilder_.Append("/v2/blocks/{round}/transactions/{txid}/proof?");
             urlBuilder_.Replace("{round}", System.Uri.EscapeDataString(ConvertToString(round, System.Globalization.CultureInfo.InvariantCulture)));
             urlBuilder_.Replace("{txid}", System.Uri.EscapeDataString(ConvertToString(txid, System.Globalization.CultureInfo.InvariantCulture)));
             if (format != null)
@@ -798,7 +791,7 @@ namespace Algorand.V2.Algod
         public async System.Threading.Tasks.Task<Response4> SupplyAsync(System.Threading.CancellationToken cancellationToken)
         {
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/v2/ledger/supply");
+            urlBuilder_.Append("/v2/ledger/supply");
 
             var client_ = _httpClient;
             var disposeClient_ = false;
@@ -882,7 +875,7 @@ namespace Algorand.V2.Algod
         public async System.Threading.Tasks.Task<NodeStatusResponse> StatusAsync(System.Threading.CancellationToken cancellationToken)
         {
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/v2/status");
+            urlBuilder_.Append("/v2/status");
 
             var client_ = _httpClient;
             var disposeClient_ = false;
@@ -981,7 +974,7 @@ namespace Algorand.V2.Algod
                 throw new System.ArgumentNullException("round");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/v2/status/wait-for-block-after/{round}");
+            urlBuilder_.Append("/v2/status/wait-for-block-after/{round}");
             urlBuilder_.Replace("{round}", System.Uri.EscapeDataString(ConvertToString(round, System.Globalization.CultureInfo.InvariantCulture)));
 
             var client_ = _httpClient;
@@ -1103,7 +1096,7 @@ namespace Algorand.V2.Algod
                 throw new System.ArgumentNullException("rawtxn");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/v2/transactions");
+            urlBuilder_.Append("/v2/transactions");
 
             var client_ = _httpClient;
             var disposeClient_ = false;
@@ -1222,7 +1215,7 @@ namespace Algorand.V2.Algod
         public async System.Threading.Tasks.Task<TransactionParametersResponse> ParamsAsync(System.Threading.CancellationToken cancellationToken)
         {
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/v2/transactions/params");
+            urlBuilder_.Append("/v2/transactions/params");
 
             var client_ = _httpClient;
             var disposeClient_ = false;
@@ -1332,7 +1325,7 @@ namespace Algorand.V2.Algod
         public async System.Threading.Tasks.Task<Response> PendingGetAsync(int? max, Format? format, System.Threading.CancellationToken cancellationToken)
         {
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/v2/transactions/pending?");
+            urlBuilder_.Append("/v2/transactions/pending?");
             if (max != null)
             {
                 urlBuilder_.Append(System.Uri.EscapeDataString("max") + "=").Append(System.Uri.EscapeDataString(ConvertToString(max, System.Globalization.CultureInfo.InvariantCulture))).Append("&");
@@ -1464,7 +1457,7 @@ namespace Algorand.V2.Algod
                 throw new System.ArgumentNullException("txid");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/v2/transactions/pending/{txid}?");
+            urlBuilder_.Append("/v2/transactions/pending/{txid}?");
             urlBuilder_.Replace("{txid}", System.Uri.EscapeDataString(ConvertToString(txid, System.Globalization.CultureInfo.InvariantCulture)));
             if (format != null)
             {
@@ -1581,7 +1574,7 @@ namespace Algorand.V2.Algod
                 throw new System.ArgumentNullException("application_id");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/v2/applications/{application-id}");
+            urlBuilder_.Append("/v2/applications/{application-id}");
             urlBuilder_.Replace("{application-id}", System.Uri.EscapeDataString(ConvertToString(application_id, System.Globalization.CultureInfo.InvariantCulture)));
 
             var client_ = _httpClient;
@@ -1703,7 +1696,7 @@ namespace Algorand.V2.Algod
                 throw new System.ArgumentNullException("asset_id");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/v2/assets/{asset-id}");
+            urlBuilder_.Append("/v2/assets/{asset-id}");
             urlBuilder_.Replace("{asset-id}", System.Uri.EscapeDataString(ConvertToString(asset_id, System.Globalization.CultureInfo.InvariantCulture)));
 
             var client_ = _httpClient;
@@ -1825,7 +1818,7 @@ namespace Algorand.V2.Algod
                 throw new System.ArgumentNullException("source");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/v2/teal/compile");
+            urlBuilder_.Append("/v2/teal/compile");
 
             var client_ = _httpClient;
             var disposeClient_ = false;
@@ -1942,7 +1935,7 @@ namespace Algorand.V2.Algod
         public async System.Threading.Tasks.Task<DryrunResponse> DryrunAsync(DryrunRequest request, System.Threading.CancellationToken cancellationToken)
         {
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/v2/teal/dryrun");
+            urlBuilder_.Append("/v2/teal/dryrun");
 
             var client_ = _httpClient;
             var disposeClient_ = false;

--- a/dotnet-algorand-sdk/V2/Algod/DefaultApi.cs
+++ b/dotnet-algorand-sdk/V2/Algod/DefaultApi.cs
@@ -279,7 +279,7 @@ namespace Algorand.V2.Algod
                 throw new System.ArgumentNullException("address");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("/v2/accounts/{address}?");
+            urlBuilder_.Append("v2/accounts/{address}?");
             urlBuilder_.Replace("{address}", System.Uri.EscapeDataString(ConvertToString(address, System.Globalization.CultureInfo.InvariantCulture)));
             if (format != null)
             {
@@ -400,7 +400,7 @@ namespace Algorand.V2.Algod
                 throw new System.ArgumentNullException("address");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("/v2/accounts/{address}/transactions/pending?");
+            urlBuilder_.Append("v2/accounts/{address}/transactions/pending?");
             urlBuilder_.Replace("{address}", System.Uri.EscapeDataString(ConvertToString(address, System.Globalization.CultureInfo.InvariantCulture)));
             if (max != null)
             {
@@ -533,7 +533,7 @@ namespace Algorand.V2.Algod
                 throw new System.ArgumentNullException("round");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("/v2/blocks/{round}?");
+            urlBuilder_.Append("v2/blocks/{round}?");
             urlBuilder_.Replace("{round}", System.Uri.EscapeDataString(ConvertToString(round, System.Globalization.CultureInfo.InvariantCulture)));
             if (format != null)
             {
@@ -668,7 +668,7 @@ namespace Algorand.V2.Algod
                 throw new System.ArgumentNullException("txid");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("/v2/blocks/{round}/transactions/{txid}/proof?");
+            urlBuilder_.Append("v2/blocks/{round}/transactions/{txid}/proof?");
             urlBuilder_.Replace("{round}", System.Uri.EscapeDataString(ConvertToString(round, System.Globalization.CultureInfo.InvariantCulture)));
             urlBuilder_.Replace("{txid}", System.Uri.EscapeDataString(ConvertToString(txid, System.Globalization.CultureInfo.InvariantCulture)));
             if (format != null)
@@ -791,7 +791,7 @@ namespace Algorand.V2.Algod
         public async System.Threading.Tasks.Task<Response4> SupplyAsync(System.Threading.CancellationToken cancellationToken)
         {
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("/v2/ledger/supply");
+            urlBuilder_.Append("v2/ledger/supply");
 
             var client_ = _httpClient;
             var disposeClient_ = false;
@@ -875,7 +875,7 @@ namespace Algorand.V2.Algod
         public async System.Threading.Tasks.Task<NodeStatusResponse> StatusAsync(System.Threading.CancellationToken cancellationToken)
         {
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("/v2/status");
+            urlBuilder_.Append("v2/status");
 
             var client_ = _httpClient;
             var disposeClient_ = false;
@@ -974,7 +974,7 @@ namespace Algorand.V2.Algod
                 throw new System.ArgumentNullException("round");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("/v2/status/wait-for-block-after/{round}");
+            urlBuilder_.Append("v2/status/wait-for-block-after/{round}");
             urlBuilder_.Replace("{round}", System.Uri.EscapeDataString(ConvertToString(round, System.Globalization.CultureInfo.InvariantCulture)));
 
             var client_ = _httpClient;
@@ -1096,7 +1096,7 @@ namespace Algorand.V2.Algod
                 throw new System.ArgumentNullException("rawtxn");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("/v2/transactions");
+            urlBuilder_.Append("v2/transactions");
 
             var client_ = _httpClient;
             var disposeClient_ = false;
@@ -1215,7 +1215,7 @@ namespace Algorand.V2.Algod
         public async System.Threading.Tasks.Task<TransactionParametersResponse> ParamsAsync(System.Threading.CancellationToken cancellationToken)
         {
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("/v2/transactions/params");
+            urlBuilder_.Append("v2/transactions/params");
 
             var client_ = _httpClient;
             var disposeClient_ = false;
@@ -1325,7 +1325,7 @@ namespace Algorand.V2.Algod
         public async System.Threading.Tasks.Task<Response> PendingGetAsync(int? max, Format? format, System.Threading.CancellationToken cancellationToken)
         {
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("/v2/transactions/pending?");
+            urlBuilder_.Append("v2/transactions/pending?");
             if (max != null)
             {
                 urlBuilder_.Append(System.Uri.EscapeDataString("max") + "=").Append(System.Uri.EscapeDataString(ConvertToString(max, System.Globalization.CultureInfo.InvariantCulture))).Append("&");
@@ -1457,7 +1457,7 @@ namespace Algorand.V2.Algod
                 throw new System.ArgumentNullException("txid");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("/v2/transactions/pending/{txid}?");
+            urlBuilder_.Append("v2/transactions/pending/{txid}?");
             urlBuilder_.Replace("{txid}", System.Uri.EscapeDataString(ConvertToString(txid, System.Globalization.CultureInfo.InvariantCulture)));
             if (format != null)
             {
@@ -1574,7 +1574,7 @@ namespace Algorand.V2.Algod
                 throw new System.ArgumentNullException("application_id");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("/v2/applications/{application-id}");
+            urlBuilder_.Append("v2/applications/{application-id}");
             urlBuilder_.Replace("{application-id}", System.Uri.EscapeDataString(ConvertToString(application_id, System.Globalization.CultureInfo.InvariantCulture)));
 
             var client_ = _httpClient;
@@ -1696,7 +1696,7 @@ namespace Algorand.V2.Algod
                 throw new System.ArgumentNullException("asset_id");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("/v2/assets/{asset-id}");
+            urlBuilder_.Append("v2/assets/{asset-id}");
             urlBuilder_.Replace("{asset-id}", System.Uri.EscapeDataString(ConvertToString(asset_id, System.Globalization.CultureInfo.InvariantCulture)));
 
             var client_ = _httpClient;
@@ -1818,7 +1818,7 @@ namespace Algorand.V2.Algod
                 throw new System.ArgumentNullException("source");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("/v2/teal/compile");
+            urlBuilder_.Append("v2/teal/compile");
 
             var client_ = _httpClient;
             var disposeClient_ = false;
@@ -1935,7 +1935,7 @@ namespace Algorand.V2.Algod
         public async System.Threading.Tasks.Task<DryrunResponse> DryrunAsync(DryrunRequest request, System.Threading.CancellationToken cancellationToken)
         {
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("/v2/teal/dryrun");
+            urlBuilder_.Append("v2/teal/dryrun");
 
             var client_ = _httpClient;
             var disposeClient_ = false;

--- a/dotnet-algorand-sdk/V2/Algod/PrivateApi.cs
+++ b/dotnet-algorand-sdk/V2/Algod/PrivateApi.cs
@@ -126,7 +126,7 @@ namespace Algorand.V2.Algod
                 throw new System.ArgumentNullException("address");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("/v2/register-participation-keys/{address}?");
+            urlBuilder_.Append("v2/register-participation-keys/{address}?");
             urlBuilder_.Replace("{address}", System.Uri.EscapeDataString(ConvertToString(address, System.Globalization.CultureInfo.InvariantCulture)));
             if (fee != null)
             {
@@ -216,7 +216,7 @@ namespace Algorand.V2.Algod
         public async System.Threading.Tasks.Task<object> ShutdownAsync(int? timeout, System.Threading.CancellationToken cancellationToken)
         {
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("/v2/shutdown?");
+            urlBuilder_.Append("v2/shutdown?");
             if (timeout != null)
             {
                 urlBuilder_.Append(System.Uri.EscapeDataString("timeout") + "=").Append(System.Uri.EscapeDataString(ConvertToString(timeout, System.Globalization.CultureInfo.InvariantCulture))).Append("&");
@@ -301,7 +301,7 @@ namespace Algorand.V2.Algod
                 throw new System.ArgumentNullException("catchpoint");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("/v2/catchup/{catchpoint}");
+            urlBuilder_.Append("v2/catchup/{catchpoint}");
             urlBuilder_.Replace("{catchpoint}", System.Uri.EscapeDataString(ConvertToString(catchpoint, System.Globalization.CultureInfo.InvariantCulture)));
 
             var client_ = _httpClient;
@@ -422,7 +422,7 @@ namespace Algorand.V2.Algod
                 throw new System.ArgumentNullException("catchpoint");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("/v2/catchup/{catchpoint}");
+            urlBuilder_.Append("v2/catchup/{catchpoint}");
             urlBuilder_.Replace("{catchpoint}", System.Uri.EscapeDataString(ConvertToString(catchpoint, System.Globalization.CultureInfo.InvariantCulture)));
 
             var client_ = _httpClient;

--- a/dotnet-algorand-sdk/V2/Algod/PrivateApi.cs
+++ b/dotnet-algorand-sdk/V2/Algod/PrivateApi.cs
@@ -75,7 +75,6 @@ namespace Algorand.V2.Algod
     [System.CodeDom.Compiler.GeneratedCode("NSwag", "13.14.5.0 (NJsonSchema v10.5.2.0 (Newtonsoft.Json v12.0.0.0))")]
     public partial class PrivateApi : IPrivateApi
     {
-        private string _baseUrl = "http://localhost/";
         private System.Net.Http.HttpClient _httpClient;
         private System.Lazy<Newtonsoft.Json.JsonSerializerSettings> _settings;
 
@@ -90,12 +89,6 @@ namespace Algorand.V2.Algod
             var settings = new Newtonsoft.Json.JsonSerializerSettings();
             UpdateJsonSerializerSettings(settings);
             return settings;
-        }
-
-        public string BaseUrl
-        {
-            get { return _baseUrl; }
-            set { _baseUrl = value; }
         }
 
         protected Newtonsoft.Json.JsonSerializerSettings JsonSerializerSettings { get { return _settings.Value; } }
@@ -133,7 +126,7 @@ namespace Algorand.V2.Algod
                 throw new System.ArgumentNullException("address");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/v2/register-participation-keys/{address}?");
+            urlBuilder_.Append("/v2/register-participation-keys/{address}?");
             urlBuilder_.Replace("{address}", System.Uri.EscapeDataString(ConvertToString(address, System.Globalization.CultureInfo.InvariantCulture)));
             if (fee != null)
             {
@@ -223,7 +216,7 @@ namespace Algorand.V2.Algod
         public async System.Threading.Tasks.Task<object> ShutdownAsync(int? timeout, System.Threading.CancellationToken cancellationToken)
         {
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/v2/shutdown?");
+            urlBuilder_.Append("/v2/shutdown?");
             if (timeout != null)
             {
                 urlBuilder_.Append(System.Uri.EscapeDataString("timeout") + "=").Append(System.Uri.EscapeDataString(ConvertToString(timeout, System.Globalization.CultureInfo.InvariantCulture))).Append("&");
@@ -308,7 +301,7 @@ namespace Algorand.V2.Algod
                 throw new System.ArgumentNullException("catchpoint");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/v2/catchup/{catchpoint}");
+            urlBuilder_.Append("/v2/catchup/{catchpoint}");
             urlBuilder_.Replace("{catchpoint}", System.Uri.EscapeDataString(ConvertToString(catchpoint, System.Globalization.CultureInfo.InvariantCulture)));
 
             var client_ = _httpClient;
@@ -429,7 +422,7 @@ namespace Algorand.V2.Algod
                 throw new System.ArgumentNullException("catchpoint");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/v2/catchup/{catchpoint}");
+            urlBuilder_.Append("/v2/catchup/{catchpoint}");
             urlBuilder_.Replace("{catchpoint}", System.Uri.EscapeDataString(ConvertToString(catchpoint, System.Globalization.CultureInfo.InvariantCulture)));
 
             var client_ = _httpClient;

--- a/dotnet-algorand-sdk/V2/HttpClientConfigurator.cs
+++ b/dotnet-algorand-sdk/V2/HttpClientConfigurator.cs
@@ -6,11 +6,13 @@ using System.Text;
 
 namespace Algorand.V2
 {
-    public  class HttpClientConfigurator
+    public class HttpClientConfigurator
     {
         public static HttpClient ConfigureHttpClient(string host, string token, string tokenHeader = "", int timeout = -1)
         {
-            var _httpClient = new HttpClient();
+            HttpClient _httpClient = new HttpClient();
+
+            _httpClient.BaseAddress = new Uri(host);
 
             if (string.IsNullOrEmpty(tokenHeader))
             {
@@ -30,7 +32,6 @@ namespace Algorand.V2
             _httpClient.Timeout = timeout > 0 ? (TimeSpan.FromMilliseconds((double)timeout)) : Timeout.InfiniteTimeSpan;
 
             return _httpClient;
-
         }
     }
 }

--- a/dotnet-algorand-sdk/V2/Indexer/CommonApi.cs
+++ b/dotnet-algorand-sdk/V2/Indexer/CommonApi.cs
@@ -36,7 +36,6 @@ namespace Algorand.V2.Indexer
     [System.CodeDom.Compiler.GeneratedCode("NSwag", "13.14.5.0 (NJsonSchema v10.5.2.0 (Newtonsoft.Json v12.0.0.0))")]
     public partial class CommonApi : ICommonApi
     {
-        private string _baseUrl = "https://example.com";
         private System.Net.Http.HttpClient _httpClient;
         private System.Lazy<Newtonsoft.Json.JsonSerializerSettings> _settings;
 
@@ -52,12 +51,6 @@ namespace Algorand.V2.Indexer
             
             UpdateJsonSerializerSettings(settings);
             return settings;
-        }
-
-        public string BaseUrl
-        {
-            get { return _baseUrl; }
-            set { _baseUrl = value; }
         }
 
         protected Newtonsoft.Json.JsonSerializerSettings JsonSerializerSettings { get { return _settings.Value; } }
@@ -83,7 +76,7 @@ namespace Algorand.V2.Indexer
         public async System.Threading.Tasks.Task<HealthCheck> HealthAsync(System.Threading.CancellationToken cancellationToken)
         {
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/health");
+            urlBuilder_.Append("/health");
 
             var client_ = _httpClient;
             var disposeClient_ = false;

--- a/dotnet-algorand-sdk/V2/Indexer/CommonApi.cs
+++ b/dotnet-algorand-sdk/V2/Indexer/CommonApi.cs
@@ -76,7 +76,7 @@ namespace Algorand.V2.Indexer
         public async System.Threading.Tasks.Task<HealthCheck> HealthAsync(System.Threading.CancellationToken cancellationToken)
         {
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("/health");
+            urlBuilder_.Append("health");
 
             var client_ = _httpClient;
             var disposeClient_ = false;

--- a/dotnet-algorand-sdk/V2/Indexer/LookupApi.cs
+++ b/dotnet-algorand-sdk/V2/Indexer/LookupApi.cs
@@ -263,7 +263,7 @@ namespace Algorand.V2.Indexer
                 throw new System.ArgumentNullException("account_id");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("/v2/accounts/{account-id}?");
+            urlBuilder_.Append("v2/accounts/{account-id}?");
             urlBuilder_.Replace("{account-id}", System.Uri.EscapeDataString(ConvertToString(account_id, System.Globalization.CultureInfo.InvariantCulture)));
             if (round != null)
             {
@@ -416,7 +416,7 @@ namespace Algorand.V2.Indexer
                 throw new System.ArgumentNullException("account_id");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("/v2/accounts/{account-id}/transactions?");
+            urlBuilder_.Append("v2/accounts/{account-id}/transactions?");
             urlBuilder_.Replace("{account-id}", System.Uri.EscapeDataString(ConvertToString(account_id, System.Globalization.CultureInfo.InvariantCulture)));
             if (limit != null)
             {
@@ -577,7 +577,7 @@ namespace Algorand.V2.Indexer
                 throw new System.ArgumentNullException("application_id");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("/v2/applications/{application-id}?");
+            urlBuilder_.Append("v2/applications/{application-id}?");
             urlBuilder_.Replace("{application-id}", System.Uri.EscapeDataString(ConvertToString(application_id, System.Globalization.CultureInfo.InvariantCulture)));
             if (include_all != null)
             {
@@ -692,7 +692,7 @@ namespace Algorand.V2.Indexer
                 throw new System.ArgumentNullException("application_id");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("/v2/applications/{application-id}/logs?");
+            urlBuilder_.Append("v2/applications/{application-id}/logs?");
             urlBuilder_.Replace("{application-id}", System.Uri.EscapeDataString(ConvertToString(application_id, System.Globalization.CultureInfo.InvariantCulture)));
             if (limit != null)
             {
@@ -797,7 +797,7 @@ namespace Algorand.V2.Indexer
                 throw new System.ArgumentNullException("asset_id");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("/v2/assets/{asset-id}?");
+            urlBuilder_.Append("v2/assets/{asset-id}?");
             urlBuilder_.Replace("{asset-id}", System.Uri.EscapeDataString(ConvertToString(asset_id, System.Globalization.CultureInfo.InvariantCulture)));
             if (include_all != null)
             {
@@ -922,7 +922,7 @@ namespace Algorand.V2.Indexer
                 throw new System.ArgumentNullException("asset_id");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("/v2/assets/{asset-id}/balances?");
+            urlBuilder_.Append("v2/assets/{asset-id}/balances?");
             urlBuilder_.Replace("{asset-id}", System.Uri.EscapeDataString(ConvertToString(asset_id, System.Globalization.CultureInfo.InvariantCulture)));
             if (include_all != null)
             {
@@ -1083,7 +1083,7 @@ namespace Algorand.V2.Indexer
                 throw new System.ArgumentNullException("asset_id");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("/v2/assets/{asset-id}/transactions?");
+            urlBuilder_.Append("v2/assets/{asset-id}/transactions?");
             urlBuilder_.Replace("{asset-id}", System.Uri.EscapeDataString(ConvertToString(asset_id, System.Globalization.CultureInfo.InvariantCulture)));
             if (limit != null)
             {
@@ -1252,7 +1252,7 @@ namespace Algorand.V2.Indexer
                 throw new System.ArgumentNullException("round_number");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("/v2/blocks/{round-number}");
+            urlBuilder_.Append("v2/blocks/{round-number}");
             urlBuilder_.Replace("{round-number}", System.Uri.EscapeDataString(ConvertToString(round_number, System.Globalization.CultureInfo.InvariantCulture)));
 
             var client_ = _httpClient;
@@ -1350,7 +1350,7 @@ namespace Algorand.V2.Indexer
                 throw new System.ArgumentNullException("txid");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("/v2/transactions/{txid}");
+            urlBuilder_.Append("v2/transactions/{txid}");
             urlBuilder_.Replace("{txid}", System.Uri.EscapeDataString(ConvertToString(txid, System.Globalization.CultureInfo.InvariantCulture)));
 
             var client_ = _httpClient;

--- a/dotnet-algorand-sdk/V2/Indexer/LookupApi.cs
+++ b/dotnet-algorand-sdk/V2/Indexer/LookupApi.cs
@@ -217,7 +217,6 @@ namespace Algorand.V2.Indexer
     [System.CodeDom.Compiler.GeneratedCode("NSwag", "13.14.5.0 (NJsonSchema v10.5.2.0 (Newtonsoft.Json v12.0.0.0))")]
     public partial class LookupApi : ILookupApi
     {
-        private string _baseUrl = "https://example.com";
         private System.Net.Http.HttpClient _httpClient;
         private System.Lazy<Newtonsoft.Json.JsonSerializerSettings> _settings;
 
@@ -232,12 +231,6 @@ namespace Algorand.V2.Indexer
             var settings = new Newtonsoft.Json.JsonSerializerSettings();
             UpdateJsonSerializerSettings(settings);
             return settings;
-        }
-
-        public string BaseUrl
-        {
-            get { return _baseUrl; }
-            set { _baseUrl = value; }
         }
 
         protected Newtonsoft.Json.JsonSerializerSettings JsonSerializerSettings { get { return _settings.Value; } }
@@ -270,7 +263,7 @@ namespace Algorand.V2.Indexer
                 throw new System.ArgumentNullException("account_id");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/v2/accounts/{account-id}?");
+            urlBuilder_.Append("/v2/accounts/{account-id}?");
             urlBuilder_.Replace("{account-id}", System.Uri.EscapeDataString(ConvertToString(account_id, System.Globalization.CultureInfo.InvariantCulture)));
             if (round != null)
             {
@@ -423,7 +416,7 @@ namespace Algorand.V2.Indexer
                 throw new System.ArgumentNullException("account_id");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/v2/accounts/{account-id}/transactions?");
+            urlBuilder_.Append("/v2/accounts/{account-id}/transactions?");
             urlBuilder_.Replace("{account-id}", System.Uri.EscapeDataString(ConvertToString(account_id, System.Globalization.CultureInfo.InvariantCulture)));
             if (limit != null)
             {
@@ -584,7 +577,7 @@ namespace Algorand.V2.Indexer
                 throw new System.ArgumentNullException("application_id");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/v2/applications/{application-id}?");
+            urlBuilder_.Append("/v2/applications/{application-id}?");
             urlBuilder_.Replace("{application-id}", System.Uri.EscapeDataString(ConvertToString(application_id, System.Globalization.CultureInfo.InvariantCulture)));
             if (include_all != null)
             {
@@ -699,7 +692,7 @@ namespace Algorand.V2.Indexer
                 throw new System.ArgumentNullException("application_id");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/v2/applications/{application-id}/logs?");
+            urlBuilder_.Append("/v2/applications/{application-id}/logs?");
             urlBuilder_.Replace("{application-id}", System.Uri.EscapeDataString(ConvertToString(application_id, System.Globalization.CultureInfo.InvariantCulture)));
             if (limit != null)
             {
@@ -804,7 +797,7 @@ namespace Algorand.V2.Indexer
                 throw new System.ArgumentNullException("asset_id");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/v2/assets/{asset-id}?");
+            urlBuilder_.Append("/v2/assets/{asset-id}?");
             urlBuilder_.Replace("{asset-id}", System.Uri.EscapeDataString(ConvertToString(asset_id, System.Globalization.CultureInfo.InvariantCulture)));
             if (include_all != null)
             {
@@ -929,7 +922,7 @@ namespace Algorand.V2.Indexer
                 throw new System.ArgumentNullException("asset_id");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/v2/assets/{asset-id}/balances?");
+            urlBuilder_.Append("/v2/assets/{asset-id}/balances?");
             urlBuilder_.Replace("{asset-id}", System.Uri.EscapeDataString(ConvertToString(asset_id, System.Globalization.CultureInfo.InvariantCulture)));
             if (include_all != null)
             {
@@ -1090,7 +1083,7 @@ namespace Algorand.V2.Indexer
                 throw new System.ArgumentNullException("asset_id");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/v2/assets/{asset-id}/transactions?");
+            urlBuilder_.Append("/v2/assets/{asset-id}/transactions?");
             urlBuilder_.Replace("{asset-id}", System.Uri.EscapeDataString(ConvertToString(asset_id, System.Globalization.CultureInfo.InvariantCulture)));
             if (limit != null)
             {
@@ -1259,7 +1252,7 @@ namespace Algorand.V2.Indexer
                 throw new System.ArgumentNullException("round_number");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/v2/blocks/{round-number}");
+            urlBuilder_.Append("/v2/blocks/{round-number}");
             urlBuilder_.Replace("{round-number}", System.Uri.EscapeDataString(ConvertToString(round_number, System.Globalization.CultureInfo.InvariantCulture)));
 
             var client_ = _httpClient;
@@ -1357,7 +1350,7 @@ namespace Algorand.V2.Indexer
                 throw new System.ArgumentNullException("txid");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/v2/transactions/{txid}");
+            urlBuilder_.Append("/v2/transactions/{txid}");
             urlBuilder_.Replace("{txid}", System.Uri.EscapeDataString(ConvertToString(txid, System.Globalization.CultureInfo.InvariantCulture)));
 
             var client_ = _httpClient;

--- a/dotnet-algorand-sdk/V2/Indexer/SearchApi.cs
+++ b/dotnet-algorand-sdk/V2/Indexer/SearchApi.cs
@@ -199,7 +199,7 @@ namespace Algorand.V2.Indexer
         public async System.Threading.Tasks.Task<Response> AccountsAsync(System.Threading.CancellationToken cancellationToken, ulong? asset_id = null, int? limit = null, string next = null, ulong? currency_greater_than = null, bool? include_all = null, ulong? currency_less_than = null, string auth_addr = null, ulong? round = null, ulong? application_id = null)
         {
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("/v2/accounts?");
+            urlBuilder_.Append("v2/accounts?");
             if (asset_id != null)
             {
                 urlBuilder_.Append(System.Uri.EscapeDataString("asset-id") + "=").Append(System.Uri.EscapeDataString(ConvertToString(asset_id, System.Globalization.CultureInfo.InvariantCulture))).Append("&");
@@ -338,7 +338,7 @@ namespace Algorand.V2.Indexer
         public async System.Threading.Tasks.Task<Response2> ApplicationsAsync(System.Threading.CancellationToken cancellationToken, ulong? application_id = null, bool? include_all = null, int? limit = null, string next = null)
         {
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("/v2/applications?");
+            urlBuilder_.Append("v2/applications?");
             if (application_id != null)
             {
                 urlBuilder_.Append(System.Uri.EscapeDataString("application-id") + "=").Append(System.Uri.EscapeDataString(ConvertToString(application_id, System.Globalization.CultureInfo.InvariantCulture))).Append("&");
@@ -453,7 +453,7 @@ namespace Algorand.V2.Indexer
         public async System.Threading.Tasks.Task<Response3> AssetsAsync(System.Threading.CancellationToken cancellationToken, bool? include_all = null, int? limit = null, string next = null, string creator = null, string name = null, string unit = null, ulong? asset_id = null)
         {
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("/v2/assets?");
+            urlBuilder_.Append("v2/assets?");
             if (include_all != null)
             {
                 urlBuilder_.Append(System.Uri.EscapeDataString("include-all") + "=").Append(System.Uri.EscapeDataString(ConvertToString(include_all, System.Globalization.CultureInfo.InvariantCulture))).Append("&");
@@ -618,7 +618,7 @@ namespace Algorand.V2.Indexer
         public async System.Threading.Tasks.Task<Response4> TransactionsAsync(System.Threading.CancellationToken cancellationToken, int? limit = null, string next = null, string note_prefix = null, TxType? tx_type = null, SigType? sig_type = null, string txid = null, ulong? round = null, ulong? min_round = null, ulong? max_round = null, ulong? asset_id = null, System.DateTimeOffset? before_time = null, System.DateTimeOffset? after_time = null, ulong? currency_greater_than = null, ulong? currency_less_than = null, string address = null, AddressRole? address_role = null, bool? exclude_close_to = null, bool? rekey_to = null, ulong? application_id = null)
         {
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("/v2/transactions?");
+            urlBuilder_.Append("v2/transactions?");
             if (limit != null)
             {
                 urlBuilder_.Append(System.Uri.EscapeDataString("limit") + "=").Append(System.Uri.EscapeDataString(ConvertToString(limit, System.Globalization.CultureInfo.InvariantCulture))).Append("&");

--- a/dotnet-algorand-sdk/V2/Indexer/SearchApi.cs
+++ b/dotnet-algorand-sdk/V2/Indexer/SearchApi.cs
@@ -144,7 +144,6 @@ namespace Algorand.V2.Indexer
     [System.CodeDom.Compiler.GeneratedCode("NSwag", "13.14.5.0 (NJsonSchema v10.5.2.0 (Newtonsoft.Json v12.0.0.0))")]
     public partial class SearchApi : ISearchApi
     {
-        private string _baseUrl = "https://example.com";
         private System.Net.Http.HttpClient _httpClient;
         private System.Lazy<Newtonsoft.Json.JsonSerializerSettings> _settings;
 
@@ -159,12 +158,6 @@ namespace Algorand.V2.Indexer
             var settings = new Newtonsoft.Json.JsonSerializerSettings();
             UpdateJsonSerializerSettings(settings);
             return settings;
-        }
-
-        public string BaseUrl
-        {
-            get { return _baseUrl; }
-            set { _baseUrl = value; }
         }
 
         protected Newtonsoft.Json.JsonSerializerSettings JsonSerializerSettings { get { return _settings.Value; } }
@@ -206,7 +199,7 @@ namespace Algorand.V2.Indexer
         public async System.Threading.Tasks.Task<Response> AccountsAsync(System.Threading.CancellationToken cancellationToken, ulong? asset_id = null, int? limit = null, string next = null, ulong? currency_greater_than = null, bool? include_all = null, ulong? currency_less_than = null, string auth_addr = null, ulong? round = null, ulong? application_id = null)
         {
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/v2/accounts?");
+            urlBuilder_.Append("/v2/accounts?");
             if (asset_id != null)
             {
                 urlBuilder_.Append(System.Uri.EscapeDataString("asset-id") + "=").Append(System.Uri.EscapeDataString(ConvertToString(asset_id, System.Globalization.CultureInfo.InvariantCulture))).Append("&");
@@ -345,7 +338,7 @@ namespace Algorand.V2.Indexer
         public async System.Threading.Tasks.Task<Response2> ApplicationsAsync(System.Threading.CancellationToken cancellationToken, ulong? application_id = null, bool? include_all = null, int? limit = null, string next = null)
         {
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/v2/applications?");
+            urlBuilder_.Append("/v2/applications?");
             if (application_id != null)
             {
                 urlBuilder_.Append(System.Uri.EscapeDataString("application-id") + "=").Append(System.Uri.EscapeDataString(ConvertToString(application_id, System.Globalization.CultureInfo.InvariantCulture))).Append("&");
@@ -460,7 +453,7 @@ namespace Algorand.V2.Indexer
         public async System.Threading.Tasks.Task<Response3> AssetsAsync(System.Threading.CancellationToken cancellationToken, bool? include_all = null, int? limit = null, string next = null, string creator = null, string name = null, string unit = null, ulong? asset_id = null)
         {
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/v2/assets?");
+            urlBuilder_.Append("/v2/assets?");
             if (include_all != null)
             {
                 urlBuilder_.Append(System.Uri.EscapeDataString("include-all") + "=").Append(System.Uri.EscapeDataString(ConvertToString(include_all, System.Globalization.CultureInfo.InvariantCulture))).Append("&");
@@ -625,7 +618,7 @@ namespace Algorand.V2.Indexer
         public async System.Threading.Tasks.Task<Response4> TransactionsAsync(System.Threading.CancellationToken cancellationToken, int? limit = null, string next = null, string note_prefix = null, TxType? tx_type = null, SigType? sig_type = null, string txid = null, ulong? round = null, ulong? min_round = null, ulong? max_round = null, ulong? asset_id = null, System.DateTimeOffset? before_time = null, System.DateTimeOffset? after_time = null, ulong? currency_greater_than = null, ulong? currency_less_than = null, string address = null, AddressRole? address_role = null, bool? exclude_close_to = null, bool? rekey_to = null, ulong? application_id = null)
         {
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/v2/transactions?");
+            urlBuilder_.Append("/v2/transactions?");
             if (limit != null)
             {
                 urlBuilder_.Append(System.Uri.EscapeDataString("limit") + "=").Append(System.Uri.EscapeDataString(ConvertToString(limit, System.Globalization.CultureInfo.InvariantCulture))).Append("&");

--- a/sdk-examples/V2/AccountTest.cs
+++ b/sdk-examples/V2/AccountTest.cs
@@ -21,7 +21,7 @@ namespace sdk_examples.V2
             Account src = new Account(SRC_ACCOUNT);
             Console.WriteLine("My account address is:" + src.Address.ToString());
             var httpClient = HttpClientConfigurator.ConfigureHttpClient(ALGOD_API_ADDR, ALGOD_API_TOKEN);
-            DefaultApi algodApiInstance = new DefaultApi(httpClient) { BaseUrl = ALGOD_API_ADDR };
+            DefaultApi algodApiInstance = new DefaultApi(httpClient);
 
             var accountInfo = await algodApiInstance.AccountsAsync(src.Address.ToString(),null);
             Console.WriteLine(string.Format("Account Balance: {0} microAlgos", accountInfo.Amount));

--- a/sdk-examples/V2/AssetExample.cs
+++ b/sdk-examples/V2/AssetExample.cs
@@ -28,7 +28,7 @@ namespace sdk_examples.V2
             string ALGOD_API_TOKEN = args[1];
 
             var httpClient = HttpClientConfigurator.ConfigureHttpClient(ALGOD_API_ADDR, ALGOD_API_TOKEN);
-            DefaultApi algodApiInstance = new DefaultApi(httpClient) { BaseUrl = ALGOD_API_ADDR };
+            DefaultApi algodApiInstance = new DefaultApi(httpClient);
 
             // Shown for demonstration purposes. NEVER reveal secret mnemonics in practice.
             // These three accounts are for testing purposes

--- a/sdk-examples/V2/AtomicTransferExample.cs
+++ b/sdk-examples/V2/AtomicTransferExample.cs
@@ -27,7 +27,7 @@ namespace sdk_examples.V2
             string DEST_ADDR2 = "OAMCXDCH7LIVYUF2HSNQLPENI2ZXCWBSOLUAOITT47E4FAMFGAMI4NFLYU";
             Algorand.Account src = new Algorand.Account(SRC_ACCOUNT);
             var httpClient = HttpClientConfigurator.ConfigureHttpClient(ALGOD_API_ADDR, ALGOD_API_TOKEN);
-            DefaultApi algodApiInstance = new DefaultApi(httpClient) { BaseUrl = ALGOD_API_ADDR };
+            DefaultApi algodApiInstance = new DefaultApi(httpClient);
             Algorand.V2.Algod.Model.TransactionParametersResponse transParams;
             try
             {

--- a/sdk-examples/V2/IndexerExamples.cs
+++ b/sdk-examples/V2/IndexerExamples.cs
@@ -10,13 +10,13 @@ namespace sdk_examples.V2
     {
         public  async Task Main(string[] args)
         {
-            string ALGOD_API_ADDR = "https://testnet-algorand.api.purestake.io/idx2";
-            string ALGOD_API_TOKEN = "GeHdp7CCGt7ApLuPNppXN4LtrW07Mm1kaFNJ5Ovr";
+            string ALGOD_API_ADDR = "https://mainnet-algorand.api.purestake.io/idx2/";
+            string ALGOD_API_TOKEN = "HFoxXc2sQf7ut4bAVmfg0adKQ6RRqTCi6nEg0YIs";
 
             var httpClient = HttpClientConfigurator.ConfigureHttpClient(ALGOD_API_ADDR, ALGOD_API_TOKEN);
-            LookupApi lookupApi = new LookupApi(httpClient) { BaseUrl = ALGOD_API_ADDR };
-            SearchApi searchApi = new SearchApi(httpClient) { BaseUrl = ALGOD_API_ADDR };
-            CommonApi commonApi = new CommonApi(httpClient) { BaseUrl = ALGOD_API_ADDR };
+            LookupApi lookupApi = new LookupApi(httpClient);
+            SearchApi searchApi = new SearchApi(httpClient);
+            CommonApi commonApi = new CommonApi(httpClient);
 
             //AlgodApi algodApiInstance = new AlgodApi(ALGOD_API_ADDR, ALGOD_API_TOKEN);
             var health = await commonApi.HealthAsync();

--- a/sdk-examples/V2/IndexerExamples.cs
+++ b/sdk-examples/V2/IndexerExamples.cs
@@ -10,8 +10,8 @@ namespace sdk_examples.V2
     {
         public  async Task Main(string[] args)
         {
-            string ALGOD_API_ADDR = "https://mainnet-algorand.api.purestake.io/idx2/";
-            string ALGOD_API_TOKEN = "HFoxXc2sQf7ut4bAVmfg0adKQ6RRqTCi6nEg0YIs";
+            string ALGOD_API_ADDR = "https://testnet-algorand.api.purestake.io/idx2/";
+            string ALGOD_API_TOKEN = "GeHdp7CCGt7ApLuPNppXN4LtrW07Mm1kaFNJ5Ovr";
 
             var httpClient = HttpClientConfigurator.ConfigureHttpClient(ALGOD_API_ADDR, ALGOD_API_TOKEN);
             LookupApi lookupApi = new LookupApi(httpClient);

--- a/sdk-examples/V2/RekeyExample.cs
+++ b/sdk-examples/V2/RekeyExample.cs
@@ -42,7 +42,7 @@ namespace sdk_examples.V2
             //build transaction
 
             var httpClient = HttpClientConfigurator.ConfigureHttpClient(ALGOD_API_ADDR, ALGOD_API_TOKEN);
-            DefaultApi algodApiInstance = new DefaultApi(httpClient) { BaseUrl = ALGOD_API_ADDR };
+            DefaultApi algodApiInstance = new DefaultApi(httpClient);
             var trans = await algodApiInstance.ParamsAsync();   
             Console.WriteLine("Lastround: " + trans.LastRound.ToString());
 

--- a/sdk-examples/V2/contract/CompileTeal.cs
+++ b/sdk-examples/V2/contract/CompileTeal.cs
@@ -19,7 +19,7 @@ namespace sdk_examples.V2.contract
 
             string ALGOD_API_TOKEN = args[1];
             var httpClient = HttpClientConfigurator.ConfigureHttpClient(ALGOD_API_ADDR, ALGOD_API_TOKEN);
-            DefaultApi algodApiInstance = new DefaultApi(httpClient) { BaseUrl = ALGOD_API_ADDR };
+            DefaultApi algodApiInstance = new DefaultApi(httpClient);
             
             // read file - int 1
             byte[] data = File.ReadAllBytes("V2\\contract\\sample.teal");

--- a/sdk-examples/V2/contract/ContractAccount.cs
+++ b/sdk-examples/V2/contract/ContractAccount.cs
@@ -21,7 +21,7 @@ namespace sdk_examples.V2.contract
             //string toAddressMnemonic = "typical permit hurdle hat song detail cattle merge oxygen crowd arctic cargo smooth fly rice vacuum lounge yard frown predict west wife latin absent cup";
             var toAddress = new Address("7XVBE6T6FMUR6TI2XGSVSOPJHKQE2SDVPMFA3QUZNWM7IY6D4K2L23ZN2A");
             var httpClient = HttpClientConfigurator.ConfigureHttpClient(ALGOD_API_ADDR, ALGOD_API_TOKEN);
-            DefaultApi algodApiInstance = new DefaultApi(httpClient) { BaseUrl = ALGOD_API_ADDR };
+            DefaultApi algodApiInstance = new DefaultApi(httpClient);
             Algorand.V2.Algod.Model.TransactionParametersResponse transParams;
             try
             {

--- a/sdk-examples/V2/contract/DryrunDedugging.cs
+++ b/sdk-examples/V2/contract/DryrunDedugging.cs
@@ -31,7 +31,7 @@ namespace sdk_examples.V2.contract
             acct1.SignLogicsig(lsig);
 
             var httpClient = HttpClientConfigurator.ConfigureHttpClient(ALGOD_API_ADDR, ALGOD_API_TOKEN);
-            DefaultApi algodApiInstance = new DefaultApi(httpClient) { BaseUrl = ALGOD_API_ADDR };
+            DefaultApi algodApiInstance = new DefaultApi(httpClient);
             Algorand.V2.Algod.Model.TransactionParametersResponse transParams;
             try
             {

--- a/sdk-examples/V2/contract/DryrunStatefulExample.cs
+++ b/sdk-examples/V2/contract/DryrunStatefulExample.cs
@@ -24,7 +24,7 @@ namespace sdk_examples.V2.contract
             }
             string ALGOD_API_TOKEN = args[1];
             var httpClient = HttpClientConfigurator.ConfigureHttpClient(ALGOD_API_ADDR, ALGOD_API_TOKEN);
-            var client = new DefaultApi(httpClient) { BaseUrl = ALGOD_API_ADDR };
+            var client = new DefaultApi(httpClient);
             //// TODO: REMOVE:
             string creatorMnemonic = "benefit once mutual legal marble hurdle dress toe fuel country prepare canvas barrel divide major square name captain calm flock crumble receive economy abandon power";
             //string userMnemonic = "pledge become mouse fantasy matrix bunker ask tissue prepare vocal unit patient cliff index train network intact company across stage faculty master mom abstract above";

--- a/sdk-examples/V2/contract/LogicSignature.cs
+++ b/sdk-examples/V2/contract/LogicSignature.cs
@@ -47,7 +47,7 @@ namespace sdk_examples.V2.contract
             //为了表示与账号1全部脱离，所以新建一个LogicsigSignature
             LogicsigSignature lsig2 = new LogicsigSignature(program, null, Convert.FromBase64String(contractSig));
             var httpClient = HttpClientConfigurator.ConfigureHttpClient(ALGOD_API_ADDR, ALGOD_API_TOKEN);
-            DefaultApi algodApiInstance = new DefaultApi(httpClient) { BaseUrl = ALGOD_API_ADDR };
+            DefaultApi algodApiInstance = new DefaultApi(httpClient);
 
             Algorand.V2.Algod.Model.TransactionParametersResponse transParams;
             try

--- a/sdk-examples/V2/contract/StatefulContract.cs
+++ b/sdk-examples/V2/contract/StatefulContract.cs
@@ -35,7 +35,7 @@ namespace sdk_examples.V2.contract
             var creator = new Account(creatorMnemonic);
             var user = new Account(userMnemonic);
             var httpClient = HttpClientConfigurator.ConfigureHttpClient(ALGOD_API_ADDR, ALGOD_API_TOKEN);
-            DefaultApi client = new DefaultApi(httpClient) { BaseUrl = ALGOD_API_ADDR };
+            DefaultApi client = new DefaultApi(httpClient);
 
             //var transParams = client.TransactionParams();
             //var tx = Utils.GetPaymentTransaction(admin.Address, creator.Address, 


### PR DESCRIPTION
This change is ultimately kind of small. The biggest thing is that baseUrl is no longer in the APIs and instead we rely on the BaseAddress being set on the HttpClient. This allows us to inject using the follow format
```
services.AddHttpClient<ISearchApi, SearchApi>(client =>
                    {
                        client.BaseAddress = new Uri(context.Configuration["Endpoints:Indexer"]);
                        client.DefaultRequestHeaders.Add("X-Algo-API-Token", context.Configuration["IndexerToken"]);
                        client.Timeout = Timeout.InfiniteTimeSpan;
                    });
```
I believe this promotes healthy HttpClient use and management and request lifecycle because this format uses IHttpClientFactory instead of individually managed HttpClients on the API objects. My only minor concern with this change is that it slightly merges concerns (the APIs now must access the httpclient to get the baseAddress if they want).