### PR TITLE
remove sender==signer check

### DIFF
--- a/dotnet-algorand-sdk/Algod/Model/Transactions/Transaction.cs
+++ b/dotnet-algorand-sdk/Algod/Model/Transactions/Transaction.cs
@@ -146,11 +146,6 @@ namespace Algorand.Algod.Model.Transactions
 
         public SignedTransaction Sign(MultisigAddress from, Account signingAccount)
         {
-            // check that from addr of tx matches multisig preimage
-            if (!Sender.ToString().Equals(from.ToString()))
-            {
-                throw new ArgumentException("Transaction sender does not match multisig account");
-            }
             // check that account secret key is in multisig pk list
             var myEncoded = signingAccount.KeyPair.ClearTextPublicKey;
             int myI = -1;


### PR DESCRIPTION
Because accounts can be re-keyed, it's not appropriate to check that the signer is the sender.